### PR TITLE
Fix Navbar component path and remove unused import

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -13,7 +13,7 @@ export default function Navbar() {
   const navLinks = [
     { href: "/", label: "Home" },
     { href: "/about", label: "About Us" },
-    { href: "/service", label: "Our Services" }, // Fixed typo: "service" to "services"
+    { href: "/service", label: "Our Services" },
     { href: "/contact", label: "Contact Us" },
   ];
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import Navbar from "@/app/components/Nabar";
+import Navbar from "@/app/components/Navbar";
 
 const inter = Inter({ subsets: ["latin"] });
 

--- a/src/app/service/page.tsx
+++ b/src/app/service/page.tsx
@@ -12,7 +12,6 @@ import {
   Users,
   Heart,
   CheckCircle,
-  ArrowRight,
   Globe,
   Award,
   Headphones,


### PR DESCRIPTION
## Summary
- rename `Nabar` component to `Navbar` and update layout import
- remove stale icon import in services page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9ad8f71a0832d882375bf8401653c