### PR TITLE
Add login and dashboard pages for tracking

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -15,6 +15,8 @@ export default function Navbar() {
     { href: "/about", label: "About Us" },
     { href: "/service", label: "Our Services" },
     { href: "/contact", label: "Contact Us" },
+    { href: "/login", label: "Login" },
+    { href: "/dashboard", label: "Dashboard" },
   ];
 
   return (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useState } from "react";
+
+export default function Dashboard() {
+  const [trackingId, setTrackingId] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus("In transit");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#FEFAE0] p-6">
+      <div className="mx-auto max-w-2xl rounded-lg bg-white p-8 shadow">
+        <h1 className="mb-6 text-2xl font-bold text-[#626F47]">Dashboard</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Enter tracking number"
+            value={trackingId}
+            onChange={(e) => setTrackingId(e.target.value)}
+            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+            required
+          />
+          <button
+            type="submit"
+            className="rounded-md bg-[#626F47] px-4 py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
+          >
+            Track Package
+          </button>
+        </form>
+        {status && (
+          <div className="mt-6 rounded-md bg-[#FFCF50]/20 p-4 text-[#626F47]">
+            <p className="font-medium">Tracking ID: {trackingId}</p>
+            <p>Status: {status}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    router.push("/dashboard");
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#FEFAE0] p-4">
+      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-lg">
+        <h1 className="mb-6 text-center text-2xl font-bold text-[#626F47]">
+          Login to TadXpress
+        </h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+            required
+          />
+          <button
+            type="submit"
+            className="w-full rounded-md bg-[#626F47] py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
+          >
+            Login
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add login page with form using existing TadXpress color palette
- add dashboard page where users can enter a tracking number and see placeholder status
- include login and dashboard links in the global navigation bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9c6551624832dab5a24223c1ee85e