### PR TITLE
Add signup and expanded dashboard for tracking

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -15,6 +15,9 @@ export default function Navbar() {
     { href: "/about", label: "About Us" },
     { href: "/service", label: "Our Services" },
     { href: "/contact", label: "Contact Us" },
+    { href: "/login", label: "Login" },
+    { href: "/signup", label: "Sign Up" },
+    { href: "/dashboard", label: "Dashboard" },
   ];
 
   return (

--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -1,0 +1,12 @@
+export default function HistoryPage() {
+  return (
+    <div className="max-w-2xl">
+      <h1 className="mb-6 text-2xl font-bold text-[#626F47]">Shipment History</h1>
+      <ul className="space-y-4">
+        <li className="rounded-md bg-white p-4 text-[#626F47] shadow">
+          No shipments yet.
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,39 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const links = [
+    { href: "/dashboard", label: "Overview" },
+    { href: "/dashboard/track", label: "Track Package" },
+    { href: "/dashboard/history", label: "Shipment History" },
+    { href: "/dashboard/profile", label: "Profile" },
+  ];
+
+  return (
+    <div className="min-h-screen flex bg-[#FEFAE0]">
+      <aside className="w-64 bg-[#626F47] text-[#FEFAE0]">
+        <div className="p-4 text-2xl font-bold">TadXpress</div>
+        <nav className="flex flex-col">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`px-4 py-2 hover:bg-[#FFCF50] hover:text-[#626F47] ${
+                pathname === link.href ? "bg-[#FFCF50] text-[#626F47]" : ""
+              }`}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,12 @@
+export default function DashboardHome() {
+  return (
+    <div className="rounded-lg bg-white p-8 shadow">
+      <h1 className="mb-4 text-2xl font-bold text-[#626F47]">
+        Welcome to TadXpress
+      </h1>
+      <p className="text-[#626F47]">
+        Use the sidebar to track your packages, view shipment history, or manage your profile.
+      </p>
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,0 +1,8 @@
+export default function ProfilePage() {
+  return (
+    <div className="max-w-xl">
+      <h1 className="mb-6 text-2xl font-bold text-[#626F47]">Profile</h1>
+      <p className="text-[#626F47]">User profile information will appear here.</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/track/page.tsx
+++ b/src/app/dashboard/track/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useState } from "react";
+
+export default function TrackPage() {
+  const [trackingId, setTrackingId] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus("In transit");
+  };
+
+  return (
+    <div className="max-w-xl">
+      <h1 className="mb-6 text-2xl font-bold text-[#626F47]">Track Package</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          placeholder="Enter tracking number"
+          value={trackingId}
+          onChange={(e) => setTrackingId(e.target.value)}
+          className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+          required
+        />
+        <button
+          type="submit"
+          className="rounded-md bg-[#626F47] px-4 py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
+        >
+          Track Package
+        </button>
+      </form>
+      {status && (
+        <div className="mt-6 rounded-md bg-[#FFCF50]/20 p-4 text-[#626F47]">
+          <p className="font-medium">Tracking ID: {trackingId}</p>
+          <p>Status: {status}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    router.push("/dashboard");
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#FEFAE0] p-4">
+      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-lg">
+        <h1 className="mb-6 text-center text-2xl font-bold text-[#626F47]">
+          Login to TadXpress
+        </h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+            required
+          />
+          <button
+            type="submit"
+            className="w-full rounded-md bg-[#626F47] py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
+          >
+            Login
+          </button>
+        </form>
+        <p className="mt-4 text-center text-sm text-[#626F47]">
+          Don&apos;t have an account? {" "}
+          <Link href="/signup" className="text-[#FFCF50]">
+            Sign Up
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export default function SignUp() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password !== confirmPassword) return;
+    router.push("/dashboard");
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#FEFAE0] p-4">
+      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-lg">
+        <h1 className="mb-6 text-center text-2xl font-bold text-[#626F47]">
+          Create an Account
+        </h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+            required
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+            required
+          />
+          <input
+            type="password"
+            placeholder="Confirm Password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+            required
+          />
+          <button
+            type="submit"
+            className="w-full rounded-md bg-[#626F47] py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
+          >
+            Sign Up
+          </button>
+        </form>
+        <p className="mt-4 text-center text-sm text-[#626F47]">
+          Already have an account? {" "}
+          <Link href="/login" className="text-[#FFCF50]">
+            Login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add signup page with TadXpress color scheme
- expand dashboard with sidebar linking to tracking, history, and profile pages
- update navigation and login to reference signup

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9c6551624832dab5a24223c1ee85e