### PR TITLE
style: modernize auth pages

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -17,42 +17,55 @@ export default function Login() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#FEFAE0] p-4">
-      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-lg">
-        <h1 className="mb-6 text-center text-2xl font-bold text-[#626F47]">
-          Login to TadXpress
-        </h1>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
-            required
+      <div className="grid w-full max-w-4xl grid-cols-1 overflow-hidden rounded-xl bg-white shadow-lg md:grid-cols-2">
+        <div className="relative hidden md:block">
+          <img
+            src="/abstract-geometric-pattern.png"
+            alt="Background"
+            className="h-full w-full object-cover"
           />
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
-            required
-          />
-          <button
-            type="submit"
-            className="w-full rounded-md bg-[#626F47] py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
-          >
-            Login
-          </button>
-        </form>
-
-        <p className="mt-4 text-center text-sm text-[#626F47]">
-          Don&apos;t have an account? {" "}
-          <Link href="/signup" className="text-[#FFCF50]">
-            Sign Up
-          </Link>
-        </p>
-
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-white/60 px-8 text-center backdrop-blur-md">
+            <h2 className="text-4xl font-bold text-[#626F47]">Welcome Back</h2>
+            <p className="mt-2 text-sm text-[#626F47]">
+              Sign in to continue your journey.
+            </p>
+          </div>
+        </div>
+        <div className="p-8">
+          <h1 className="mb-6 text-center text-2xl font-bold text-[#626F47]">
+            Login to TadXpress
+          </h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+              required
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+              required
+            />
+            <button
+              type="submit"
+              className="w-full rounded-md bg-[#626F47] py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
+            >
+              Login
+            </button>
+          </form>
+          <p className="mt-4 text-center text-sm text-[#626F47]">
+            Don&apos;t have an account? {" "}
+            <Link href="/signup" className="text-[#FFCF50]">
+              Sign Up
+            </Link>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -18,56 +18,81 @@ export default function SignUp() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#FEFAE0] p-4">
-      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-lg">
-        <h1 className="mb-6 text-center text-2xl font-bold text-[#626F47]">
-          Create an Account
-        </h1>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            placeholder="Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
-            required
+      <div className="grid w-full max-w-4xl grid-cols-1 overflow-hidden rounded-xl bg-white shadow-lg md:grid-cols-2">
+        <div className="relative hidden md:block">
+          <img
+            src="/abstract-geometric-pattern.png"
+            alt="Background"
+            className="h-full w-full object-cover"
           />
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
-            required
-          />
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
-            required
-          />
-          <input
-            type="password"
-            placeholder="Confirm Password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
-            required
-          />
-          <button
-            type="submit"
-            className="w-full rounded-md bg-[#626F47] py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
-          >
-            Sign Up
-          </button>
-        </form>
-        <p className="mt-4 text-center text-sm text-[#626F47]">
-          Already have an account? {" "}
-          <Link href="/login" className="text-[#FFCF50]">
-            Login
-          </Link>
-        </p>
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-white/60 px-8 text-center backdrop-blur-md">
+            <h2 className="text-4xl font-bold text-[#626F47]">Sign Up</h2>
+            <p className="mt-2 text-sm text-[#626F47]">
+              Join us to unlock an exciting experience with our services.
+            </p>
+          </div>
+        </div>
+        <div className="p-8">
+          <h1 className="mb-6 text-center text-2xl font-bold text-[#626F47]">
+            Create an Account
+          </h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input
+              type="text"
+              placeholder="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+              required
+            />
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+              required
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+              required
+            />
+            <input
+              type="password"
+              placeholder="Confirm Password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
+              required
+            />
+            <p className="text-center text-xs text-[#626F47]">
+              By continuing you agree to our {" "}
+              <Link href="#" className="text-[#FFCF50]">
+                Terms & Conditions
+              </Link>{" "}
+              and {" "}
+              <Link href="#" className="text-[#FFCF50]">
+                Privacy Policy
+              </Link>
+            </p>
+            <button
+              type="submit"
+              className="w-full rounded-md bg-[#626F47] py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
+            >
+              Create Account
+            </button>
+          </form>
+          <p className="mt-4 text-center text-sm text-[#626F47]">
+            Already have an account? {" "}
+            <Link href="/login" className="text-[#FFCF50]">
+              Login
+            </Link>
+          </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- restyle login page with image split layout
- restyle signup page with onboarding message and terms notice

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba108eeff0832d913db7e282803d09