### PR TITLE
feat: redesign dashboard layout

### DIFF
--- a/src/app/dashboard/components/StatCard.tsx
+++ b/src/app/dashboard/components/StatCard.tsx
@@ -1,0 +1,19 @@
+export default function StatCard({
+  title,
+  value,
+  icon,
+}: {
+  title: string;
+  value: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-4 rounded-xl bg-white p-4 shadow">
+      <div className="rounded-lg bg-blue-100 p-2 text-blue-600">{icon}</div>
+      <div>
+        <p className="text-sm text-gray-500">{title}</p>
+        <p className="text-xl font-semibold text-gray-900">{value}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,13 @@
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import Image from "next/image";
+import {
+  HomeIcon,
+  MagnifyingGlassIcon,
+  ClockIcon,
+  UserIcon,
+} from "@heroicons/react/24/outline";
 
 export default function DashboardLayout({
   children,
@@ -9,31 +16,53 @@ export default function DashboardLayout({
 }) {
   const pathname = usePathname();
   const links = [
-    { href: "/dashboard", label: "Overview" },
-    { href: "/dashboard/track", label: "Track Package" },
-    { href: "/dashboard/history", label: "Shipment History" },
-    { href: "/dashboard/profile", label: "Profile" },
+    { href: "/dashboard", label: "Dashboard", icon: HomeIcon },
+    { href: "/dashboard/track", label: "Track", icon: MagnifyingGlassIcon },
+    { href: "/dashboard/history", label: "History", icon: ClockIcon },
+    { href: "/dashboard/profile", label: "Profile", icon: UserIcon },
   ];
 
   return (
-    <div className="min-h-screen flex bg-[#FEFAE0]">
-      <aside className="w-64 bg-[#626F47] text-[#FEFAE0]">
-        <div className="p-4 text-2xl font-bold">TadXpress</div>
-        <nav className="flex flex-col">
-          {links.map((link) => (
+    <div className="flex min-h-screen bg-gray-100">
+      <aside className="flex w-64 flex-col bg-white p-6 shadow-sm">
+        <div className="mb-8 text-2xl font-bold text-blue-600">TadXpress</div>
+        <nav className="space-y-2">
+          {links.map(({ href, label, icon: Icon }) => (
             <Link
-              key={link.href}
-              href={link.href}
-              className={`px-4 py-2 hover:bg-[#FFCF50] hover:text-[#626F47] ${
-                pathname === link.href ? "bg-[#FFCF50] text-[#626F47]" : ""
+              key={href}
+              href={href}
+              className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium hover:bg-blue-50 ${
+                pathname === href
+                  ? "bg-blue-100 text-blue-700"
+                  : "text-gray-700"
               }`}
             >
-              {link.label}
+              <Icon className="h-5 w-5" />
+              {label}
             </Link>
           ))}
         </nav>
       </aside>
-      <main className="flex-1 p-6">{children}</main>
+      <div className="flex flex-1 flex-col">
+        <header className="flex items-center justify-between border-b bg-white p-4">
+          <input
+            type="text"
+            placeholder="Search anything here..."
+            className="w-full max-w-md rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <div className="ml-4 flex items-center gap-3">
+            <Image
+              src="/vercel.svg"
+              alt="User"
+              width={32}
+              height={32}
+              className="rounded-full"
+            />
+            <span className="text-sm font-medium">Peter Gross</span>
+          </div>
+        </header>
+        <main className="flex-1 p-6">{children}</main>
+      </div>
     </div>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,41 +1,101 @@
 "use client";
-import { useState } from "react";
+import Image from "next/image";
+import { Package, Truck, CheckCircle2, Star } from "lucide-react";
+import StatCard from "./components/StatCard";
 
 export default function Dashboard() {
-  const [trackingId, setTrackingId] = useState("");
-  const [status, setStatus] = useState<string | null>(null);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    setStatus("In transit");
-  };
+  const stats = [
+    { title: "Total shipments", value: "120", icon: <Package className="h-6 w-6" /> },
+    { title: "In transit", value: "80", icon: <Truck className="h-6 w-6" /> },
+    { title: "Delivered", value: "40", icon: <CheckCircle2 className="h-6 w-6" /> },
+  ];
 
   return (
-    <div className="min-h-screen bg-[#FEFAE0] p-6">
-      <div className="mx-auto max-w-2xl rounded-lg bg-white p-8 shadow">
-        <h1 className="mb-6 text-2xl font-bold text-[#626F47]">Dashboard</h1>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            placeholder="Enter tracking number"
-            value={trackingId}
-            onChange={(e) => setTrackingId(e.target.value)}
-            className="w-full rounded-md border border-[#626F47] px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#FFCF50]"
-            required
-          />
-          <button
-            type="submit"
-            className="rounded-md bg-[#626F47] px-4 py-2 font-semibold text-[#FEFAE0] transition hover:bg-[#FFCF50] hover:text-[#626F47]"
-          >
-            Track Package
-          </button>
-        </form>
-        {status && (
-          <div className="mt-6 rounded-md bg-[#FFCF50]/20 p-4 text-[#626F47]">
-            <p className="font-medium">Tracking ID: {trackingId}</p>
-            <p>Status: {status}</p>
+    <div className="space-y-6">
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {stats.map((stat) => (
+          <StatCard key={stat.title} {...stat} />
+        ))}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-2">
+          <div className="rounded-xl bg-white p-4 shadow">
+            <h2 className="mb-4 text-lg font-semibold text-gray-700">Calendar</h2>
+            <div className="grid grid-cols-7 gap-2 text-center text-sm">
+              {Array.from({ length: 28 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="aspect-square rounded-lg bg-blue-50"
+                ></div>
+              ))}
+            </div>
           </div>
-        )}
+          <div className="rounded-xl bg-white p-4 shadow">
+            <h2 className="mb-4 text-lg font-semibold text-gray-700">Schedule of shipments</h2>
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="text-gray-500">
+                  <th className="p-2">Shipment</th>
+                  <th className="p-2">Destination</th>
+                  <th className="p-2">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-t">
+                  <td className="p-2">PX-01</td>
+                  <td className="p-2">Berlin</td>
+                  <td className="p-2 text-green-600">Delivered</td>
+                </tr>
+                <tr className="border-t">
+                  <td className="p-2">PX-02</td>
+                  <td className="p-2">Munich</td>
+                  <td className="p-2 text-yellow-600">In transit</td>
+                </tr>
+                <tr className="border-t">
+                  <td className="p-2">PX-03</td>
+                  <td className="p-2">Hamburg</td>
+                  <td className="p-2 text-blue-600">Pending</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div className="rounded-xl bg-white p-4 shadow">
+            <h2 className="mb-4 text-lg font-semibold text-gray-700">Rating</h2>
+            <div className="flex items-center gap-1">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Star
+                  key={i}
+                  className={`h-5 w-5 ${i < 4 ? "text-yellow-400" : "text-gray-300"}`}
+                  fill={i < 4 ? "currentColor" : "none"}
+                />
+              ))}
+              <span className="ml-2 text-sm text-gray-600">4.0</span>
+            </div>
+          </div>
+          <div className="rounded-xl bg-white p-4 shadow">
+            <h2 className="mb-4 text-lg font-semibold text-gray-700">Current shipment</h2>
+            <div className="flex h-40 items-center justify-center rounded-lg bg-gray-100 text-gray-500">
+              Map placeholder
+            </div>
+          </div>
+          <div className="rounded-xl bg-white p-4 shadow">
+            <h2 className="mb-4 text-lg font-semibold text-gray-700">Current vehicle</h2>
+            <div className="flex flex-col items-center">
+              <Image
+                src="/globe.svg"
+                alt="Vehicle"
+                width={160}
+                height={80}
+                className="mb-2"
+              />
+              <p className="text-sm text-gray-600">Volvo FH16</p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- revamp dashboard layout with sidebar navigation and top search bar
- add stat cards, calendar, schedule table, rating and vehicle widgets
- create reusable StatCard component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba15f362d8832dac1999e487f666f6