### PR TITLE
feat: redesign dashboard navigation

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,12 +1,22 @@
 "use client";
+
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Image from "next/image";
 import {
+  ArrowLeftOnRectangleIcon,
+  BellIcon,
+  CalendarDaysIcon,
+  ChartBarSquareIcon,
+  ChevronDownIcon,
+  Cog6ToothIcon,
+  EnvelopeIcon,
+  FlagIcon,
+  GlobeAltIcon,
   HomeIcon,
-  MagnifyingGlassIcon,
-  ClockIcon,
-  UserIcon,
+  MapIcon,
+  QuestionMarkCircleIcon,
+  TruckIcon,
 } from "@heroicons/react/24/outline";
 
 export default function DashboardLayout({
@@ -15,56 +25,94 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-  const links = [
+
+  const mainLinks = [
     { href: "/dashboard", label: "Dashboard", icon: HomeIcon },
-    { href: "/dashboard/track", label: "Track", icon: MagnifyingGlassIcon },
-    { href: "/dashboard/history", label: "History", icon: ClockIcon },
-    { href: "/dashboard/profile", label: "Profile", icon: UserIcon },
+    { href: "#", label: "Trips", icon: MapIcon },
+    { href: "#", label: "Schedule", icon: CalendarDaysIcon },
+    { href: "#", label: "Messages", icon: EnvelopeIcon, badge: "2" },
+    { href: "#", label: "Analytics", icon: ChartBarSquareIcon },
+    { href: "#", label: "Vehicles", icon: TruckIcon },
+    { href: "#", label: "Report", icon: FlagIcon },
+    { href: "#", label: "Support", icon: QuestionMarkCircleIcon },
+  ];
+
+  const bottomLinks = [
+    { href: "#", label: "Settings", icon: Cog6ToothIcon },
+    { href: "#", label: "Log out", icon: ArrowLeftOnRectangleIcon },
   ];
 
   return (
     <div className="flex min-h-screen bg-gray-100">
-      <aside className="flex w-64 flex-col bg-white p-6 shadow-sm">
-
-        <div className="mb-8 text-2xl font-bold text-brand-primary">TadXpress</div>
-
-        <nav className="space-y-2">
-          {links.map(({ href, label, icon: Icon }) => (
+      <aside className="flex w-64 flex-col justify-between bg-white px-4 py-6 shadow-sm">
+        <div>
+          <div className="mb-8 flex items-center gap-2 px-2">
+            <GlobeAltIcon className="h-6 w-6 text-blue-600" />
+            <span className="text-lg font-bold text-gray-800">GLOBALRIDE</span>
+          </div>
+          <nav className="space-y-1">
+            {mainLinks.map(({ href, label, icon: Icon, badge }) => (
+              <Link
+                key={href + label}
+                href={href}
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium hover:bg-blue-50 ${
+                  pathname === href ? "bg-blue-50 text-blue-600" : "text-gray-700"
+                }`}
+              >
+                <Icon className="h-5 w-5" />
+                <span className="flex-1">{label}</span>
+                {badge && (
+                  <span className="rounded bg-blue-600 px-1.5 py-0.5 text-xs font-semibold text-white">
+                    {badge}
+                  </span>
+                )}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <div className="space-y-1 border-t pt-4">
+          {bottomLinks.map(({ href, label, icon: Icon }) => (
             <Link
-              key={href}
+              key={href + label}
               href={href}
-
-              className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium hover:bg-brand-primary-light ${
-                pathname === href
-                  ? "bg-brand-primary-light text-brand-primary-dark"
-
-                  : "text-gray-700"
-              }`}
+              className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-gray-700 hover:bg-blue-50"
             >
               <Icon className="h-5 w-5" />
               {label}
             </Link>
           ))}
-        </nav>
+        </div>
       </aside>
+
       <div className="flex flex-1 flex-col">
-        <header className="flex items-center justify-between border-b bg-white p-4">
-          <input
-            type="text"
-            placeholder="Search anything here..."
-
-            className="w-full max-w-md rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary"
-
-          />
-          <div className="ml-4 flex items-center gap-3">
-            <Image
-              src="/vercel.svg"
-              alt="User"
-              width={32}
-              height={32}
-              className="rounded-full"
+        <header className="flex items-center justify-between bg-white px-6 py-4 shadow-sm">
+          <div className="flex flex-1 items-center gap-4">
+            <div className="flex items-center gap-2">
+              <GlobeAltIcon className="h-6 w-6 text-blue-600" />
+              <span className="text-lg font-semibold text-gray-800">GLOBALRIDE</span>
+            </div>
+            <input
+              type="text"
+              placeholder="Search anything here..."
+              className="ml-4 w-full max-w-md flex-1 rounded-full border bg-gray-50 px-4 py-2 text-sm focus:outline-none"
             />
-            <span className="text-sm font-medium">Peter Gross</span>
+          </div>
+          <div className="ml-6 flex items-center gap-4">
+            <BellIcon className="h-6 w-6 text-gray-500" />
+            <div className="flex items-center gap-2 rounded-full bg-gray-100 p-1 pr-3">
+              <Image
+                src="/vercel.svg"
+                alt="User"
+                width={32}
+                height={32}
+                className="rounded-full"
+              />
+              <div className="text-left">
+                <p className="text-sm font-medium leading-tight">Peter Gross</p>
+                <p className="text-xs leading-tight text-gray-500">Driver</p>
+              </div>
+              <ChevronDownIcon className="h-4 w-4 text-gray-500" />
+            </div>
           </div>
         </header>
         <main className="flex-1 p-6">{children}</main>
@@ -72,3 +120,4 @@ export default function DashboardLayout({
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- update dashboard layout with GLOBALRIDE-branded sidebar links and account actions
- add top navbar with search, notifications, and user profile capsule

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ba1f5a43a8832db7c931eacac72f72