### PR TITLE
style: enhance current trip timeline

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -106,25 +106,38 @@ export default function Dashboard() {
         {/* Current trip */}
         <div className="rounded-xl bg-white p-4 shadow">
           <h2 className="mb-4 text-lg font-semibold text-brand-primary-dark">Current trip</h2>
-          <ul className="space-y-2 text-sm">
-            <li>
-              <p className="text-gray-500">Departure</p>
-              <p className="font-medium">Poznan, Bus Station</p>
-              <p className="text-xs text-gray-400">12:45 AM</p>
-            </li>
-            <li>
-              <p className="text-gray-500">Stop</p>
-              <p className="font-medium">Berlin Airport BER, T1/2</p>
-            </li>
-            <li>
-              <p className="text-gray-500">Arrival</p>
-              <p className="font-medium">Berlin Südkreuz</p>
-              <p className="text-xs text-gray-400">4:30 AM</p>
-            </li>
-          </ul>
-          <button className="mt-4 w-full rounded-lg bg-brand-primary-light py-2 text-sm text-brand-primary">
-            Duration: 3 hours 45 min
-          </button>
+          <div className="relative pl-6">
+            <div className="absolute left-2 top-0 h-full w-px bg-brand-primary-light"></div>
+            <ul className="space-y-6 text-sm">
+              <li className="relative flex items-start justify-between">
+                <span className="absolute -left-4 top-1 h-3 w-3 rounded-full bg-brand-primary"></span>
+                <div className="max-w-[70%]">
+                  <p className="text-gray-500">Departure</p>
+                  <p className="font-medium">Poznan, Bus Station</p>
+                </div>
+                <p className="text-xs text-gray-400">12:45 AM</p>
+              </li>
+              <li className="relative flex items-start justify-between">
+                <MapPin className="absolute -left-4 top-1 h-3 w-3 text-gray-500" />
+                <div className="max-w-[70%]">
+                  <p className="text-gray-500">Stop</p>
+                  <p className="font-medium">Berlin Airport BER, T 1/2</p>
+                </div>
+                <p className="text-xs text-gray-400">4:05 AM</p>
+              </li>
+              <li className="relative flex items-start justify-between">
+                <MapPin className="absolute -left-4 top-1 h-3 w-3 text-gray-500" />
+                <div className="max-w-[70%]">
+                  <p className="text-gray-500">Arrival</p>
+                  <p className="font-medium">Berlin Südkreuz</p>
+                </div>
+                <p className="text-xs text-gray-400">4:30 AM</p>
+              </li>
+            </ul>
+            <button className="mt-6 w-full rounded-lg bg-brand-primary-light py-2 text-sm text-brand-primary">
+              Duration: 3 hours 45 min
+            </button>
+          </div>
         </div>
 
         {/* Map */}


### PR DESCRIPTION
## Summary
- refactor current trip card in dashboard to show a vertical timeline with departure, stop, and arrival details
- add icons and time labels mirroring the intended design

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba25234508832db963723526317a2d