### PR TITLE
revert: restore auth pages to earlier design

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/app/components/Navbar";
+
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Tadxpres - Logistics Delivery Service",
@@ -14,7 +17,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="bg-gray-50 text-gray-900">
+      <body className={`${inter.className} bg-gray-50 text-gray-900`}>
         <Navbar />
         {children}
       </body>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 import Link from "next/link";
-import Image from "next/image";
 
 export default function Login() {
   const router = useRouter();
@@ -19,12 +18,10 @@ export default function Login() {
     <div className="flex min-h-screen items-center justify-center bg-[#FEFAE0] p-4">
       <div className="grid w-full max-w-4xl grid-cols-1 overflow-hidden rounded-xl bg-white shadow-lg md:grid-cols-2">
         <div className="relative hidden md:block">
-          <Image
-            src="/abstract-geometric-pattern.png"
+          <img
+            src="https://images.unsplash.com/photo-1619741982598-7cb8a7959476?q=80&w=870&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3Dg"
             alt="Background"
-            fill
-            className="object-cover"
-            priority
+            className="h-full w-full object-cover"
           />
           <div className="absolute inset-0 flex flex-col items-center justify-center bg-white/60 px-8 text-center backdrop-blur-md">
             <h2 className="text-4xl font-bold text-[#626F47]">Welcome Back</h2>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -2,7 +2,6 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
 
 export default function SignUp() {
   const router = useRouter();
@@ -21,12 +20,10 @@ export default function SignUp() {
     <div className="flex min-h-screen items-center justify-center bg-[#FEFAE0] p-4">
       <div className="grid w-full max-w-4xl grid-cols-1 overflow-hidden rounded-xl bg-white shadow-lg md:grid-cols-2">
         <div className="relative hidden md:block">
-          <Image
-            src="/abstract-geometric-pattern.png"
+          <img
+            src="https://images.unsplash.com/photo-1619741982598-7cb8a7959476?q=80&w=870&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
             alt="Background"
-            fill
-            className="object-cover"
-            priority
+            className="h-full w-full object-cover"
           />
           <div className="absolute inset-0 flex flex-col items-center justify-center bg-white/60 px-8 text-center backdrop-blur-md">
             <h2 className="text-4xl font-bold text-[#626F47]">Sign Up</h2>


### PR DESCRIPTION
## Summary
- restore Inter font and navbar layout in root layout
- revert login and signup pages to use original unsplash `<img>` backgrounds

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68baa1573380832d81fa81ad38dc856c