### PR TITLE
Add basic dashboards and role-based login

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+interface Person {
+  name: string;
+  email: string;
+}
+
+const users: Person[] = [
+  { name: "Jane Passenger", email: "jane@example.com" },
+  { name: "John Passenger", email: "john@example.com" },
+];
+
+const riders: Person[] = [
+  { name: "Rider One", email: "rider1@example.com" },
+  { name: "Rider Two", email: "rider2@example.com" },
+];
+
+export default function AdminDashboard() {
+  return (
+    <main className="mx-auto max-w-2xl space-y-8 p-4">
+      <h1 className="text-2xl font-bold text-[#626F47]">Admin Dashboard</h1>
+
+      <section>
+        <h2 className="mb-2 text-xl font-semibold text-[#626F47]">Users</h2>
+        <ul className="space-y-2">
+          {users.map((u, i) => (
+            <li
+              key={i}
+              className="flex justify-between rounded-lg bg-white p-4 shadow"
+            >
+              <span>{u.name}</span>
+              <span className="text-sm text-gray-500">{u.email}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-xl font-semibold text-[#626F47]">Riders</h2>
+        <ul className="space-y-2">
+          {riders.map((r, i) => (
+            <li
+              key={i}
+              className="flex justify-between rounded-lg bg-white p-4 shadow"
+            >
+              <span>{r.name}</span>
+              <span className="text-sm text-gray-500">{r.email}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,17 +1,17 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-
 import Link from "next/link";
 
 export default function Login() {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [role, setRole] = useState("user");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    router.push("/dashboard");
+    router.push(`/${role}/dashboard`);
   };
 
   return (
@@ -35,6 +35,25 @@ export default function Login() {
             Login to TadXpress
           </h1>
           <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="flex justify-center gap-4">
+              {[
+                { value: "user", label: "User" },
+                { value: "rider", label: "Rider" },
+                { value: "admin", label: "Admin" },
+              ].map((opt) => (
+                <label key={opt.value} className="flex items-center gap-1 text-sm">
+                  <input
+                    type="radio"
+                    name="role"
+                    value={opt.value}
+                    checked={role === opt.value}
+                    onChange={(e) => setRole(e.target.value)}
+                    className="text-[#626F47]"
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
             <input
               type="email"
               placeholder="Email"

--- a/src/app/rider/dashboard/page.tsx
+++ b/src/app/rider/dashboard/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getRides, saveRide, Ride } from "@/lib/rides";
+
+export default function RiderDashboard() {
+  const [location, setLocation] = useState("");
+  const [time, setTime] = useState("");
+  const [rides, setRides] = useState<Ride[]>([]);
+
+  useEffect(() => {
+    setRides(getRides());
+  }, []);
+
+  const addRide = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!location || !time) return;
+    saveRide({ location, time });
+    setRides(getRides());
+    setLocation("");
+    setTime("");
+  };
+
+  return (
+    <main className="max-w-2xl mx-auto p-4 space-y-6">
+      <h1 className="text-2xl font-bold text-[#626F47]">Rider Dashboard</h1>
+      <form onSubmit={addRide} className="space-y-2">
+        <input
+          type="text"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          className="w-full rounded-md border px-4 py-2"
+        />
+        <input
+          type="text"
+          placeholder="Time"
+          value={time}
+          onChange={(e) => setTime(e.target.value)}
+          className="w-full rounded-md border px-4 py-2"
+        />
+        <button
+          type="submit"
+          className="rounded bg-[#626F47] px-4 py-2 text-[#FEFAE0] hover:bg-[#FFCF50] hover:text-[#626F47]"
+        >
+          Add Ride
+        </button>
+      </form>
+      <div className="space-y-2">
+        {rides.map((ride, i) => (
+          <div key={i} className="rounded-lg bg-white p-4 shadow">
+            <p className="font-medium">{ride.location}</p>
+            <p className="text-sm text-gray-500">{ride.time}</p>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -9,11 +9,12 @@ export default function SignUp() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [role, setRole] = useState("user");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (password !== confirmPassword) return;
-    router.push("/dashboard");
+    router.push(`/${role}/dashboard`);
   };
 
   return (
@@ -37,6 +38,24 @@ export default function SignUp() {
             Create an Account
           </h1>
           <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="flex justify-center gap-4">
+              {[
+                { value: "user", label: "User" },
+                { value: "rider", label: "Rider" },
+              ].map((opt) => (
+                <label key={opt.value} className="flex items-center gap-1 text-sm">
+                  <input
+                    type="radio"
+                    name="role"
+                    value={opt.value}
+                    checked={role === opt.value}
+                    onChange={(e) => setRole(e.target.value)}
+                    className="text-[#626F47]"
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
             <input
               type="text"
               placeholder="Name"

--- a/src/app/user/dashboard/page.tsx
+++ b/src/app/user/dashboard/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getRides, Ride } from "@/lib/rides";
+
+export default function UserDashboard() {
+  const [rides, setRides] = useState<Ride[]>([]);
+
+  useEffect(() => {
+    setRides(getRides());
+  }, []);
+
+  return (
+    <main className="max-w-2xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-[#626F47]">Available Rides</h1>
+      {rides.length === 0 && (
+        <p className="text-center text-gray-500">No rides available.</p>
+      )}
+      {rides.map((ride, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-between rounded-lg bg-white p-4 shadow"
+        >
+          <div>
+            <p className="font-medium">{ride.location}</p>
+            <p className="text-sm text-gray-500">{ride.time}</p>
+          </div>
+          <a
+            href="https://wa.me/08145765479"
+            target="_blank"
+            className="rounded bg-[#626F47] px-3 py-1 text-[#FEFAE0] hover:bg-[#FFCF50] hover:text-[#626F47]"
+          >
+            Book
+          </a>
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/src/lib/rides.ts
+++ b/src/lib/rides.ts
@@ -1,0 +1,18 @@
+"use client";
+
+export interface Ride {
+  location: string;
+  time: string;
+}
+
+export function getRides(): Ride[] {
+  if (typeof window === "undefined") return [];
+  const data = localStorage.getItem("rides");
+  return data ? JSON.parse(data) : [];
+}
+
+export function saveRide(ride: Ride) {
+  const rides = getRides();
+  rides.push(ride);
+  localStorage.setItem("rides", JSON.stringify(rides));
+}


### PR DESCRIPTION
## Summary
- add local ride store and dashboards for user, rider, and admin
- allow riders to add rides that users can book via WhatsApp
- update login and signup to select role and route to correct dashboard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68baaa0662a0832d88e2e909c9b2bd38